### PR TITLE
Usability Updates - node version installation, task configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 out
 download
+.idea

--- a/about/src/main/groovy/com/github/goldin/plugins/gradle/about/AboutTask.groovy
+++ b/about/src/main/groovy/com/github/goldin/plugins/gradle/about/AboutTask.groovy
@@ -19,6 +19,8 @@ class AboutTask extends BaseTask<AboutExtension>
     @Override
     void verifyUpdateExtension ( String description ) {}
 
+    @Requires({ c })
+    void about( Closure c ){ config(c) }
 
     @Override
     void taskAction()

--- a/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BaseTask.groovy
+++ b/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BaseTask.groovy
@@ -75,6 +75,7 @@ abstract class BaseTask<T extends BaseExtension> extends DefaultTask
         {
             this.extensionName = this.name
             this.ext           = project.extensions.create( this.extensionName, extensionType())
+            this.config.delegate = this.ext
             this.config( this.ext )
         }
 

--- a/common/src/main/resources/node-setup.sh
+++ b/common/src/main/resources/node-setup.sh
@@ -45,7 +45,10 @@ set -o pipefail
 
 . "$NVM_SH"
 
-nvm install @{nodeVersion}
+nvm ls @{nodeVersion}
+if [ $? -ne 0 ]; then
+    nvm install @{nodeVersion}
+fi
 nvm use     @{nodeVersion}
 
 echo "npm  : [`which npm`][`npm --version`]"

--- a/crawler/src/main/groovy/com/github/goldin/plugins/gradle/crawler/CrawlerTask.groovy
+++ b/crawler/src/main/groovy/com/github/goldin/plugins/gradle/crawler/CrawlerTask.groovy
@@ -28,6 +28,8 @@ class CrawlerTask extends BaseTask<CrawlerExtension>
     private          ThreadPoolExecutor threadPool
     private          LinksStorage       linksStorage
 
+    @Requires({ c })
+    void crawler( Closure c ){ config(c) }
 
     /**
      * Verifies {@link CrawlerExtension} contains proper settings and updates it with additional properties.

--- a/duplicates/src/main/groovy/com/github/goldin/plugins/gradle/duplicates/DuplicatesTask.groovy
+++ b/duplicates/src/main/groovy/com/github/goldin/plugins/gradle/duplicates/DuplicatesTask.groovy
@@ -25,6 +25,9 @@ class DuplicatesTask extends BaseTask<DuplicatesExtension>
      */
     private final Map<File, List<String>> classesCache = [:]
 
+    @Requires({ c })
+    void duplicates( Closure c ){ config(c) }
+
     @Override
     void verifyUpdateExtension ( String description ) {}
 

--- a/gitdump/src/main/groovy/com/github/goldin/plugins/gradle/gitdump/GitDumpTask.groovy
+++ b/gitdump/src/main/groovy/com/github/goldin/plugins/gradle/gitdump/GitDumpTask.groovy
@@ -29,6 +29,8 @@ class GitDumpTask extends BaseTask<GitDumpExtension>
     @Ensures({ result })
     private String lastCommitCurrentBranch ( File projectDirectory ){ gitExec( 'log -1 --format=format:%H', projectDirectory ) }
 
+    @Requires({ c })
+    void gitdump( Closure c ){ config(c) }
 
     @Override
     void verifyUpdateExtension ( String description )

--- a/monitor/src/main/groovy/com/github/goldin/plugins/gradle/monitor/MonitorTask.groovy
+++ b/monitor/src/main/groovy/com/github/goldin/plugins/gradle/monitor/MonitorTask.groovy
@@ -23,6 +23,8 @@ class MonitorTask extends BaseTask<MonitorExtension>
     // http://stackoverflow.com/questions/10258101/sslhandshakeexception-no-subject-alternative-names-present?answertab=active#tab-top
     static { HttpsURLConnection.defaultHostnameVerifier = { String hostname, SSLSession session -> true } as HostnameVerifier }
 
+    @Requires({ c })
+    void monitor( Closure c ){ config(c) }
 
     @Override
     void verifyUpdateExtension ( String description )

--- a/node/src/main/groovy/com/github/goldin/plugins/gradle/node/tasks/NodeBaseTask.groovy
+++ b/node/src/main/groovy/com/github/goldin/plugins/gradle/node/tasks/NodeBaseTask.groovy
@@ -31,6 +31,8 @@ abstract class NodeBaseTask extends BaseTask<NodeExtension>
      */
     protected boolean requiresScriptPath(){ false }
 
+    @Requires({ c })
+    void node( Closure c ){ config(c) }
 
     @Override
     void verifyUpdateExtension ( String description )

--- a/play/src/main/groovy/com/github/goldin/plugins/gradle/play/tasks/PlayBaseTask.groovy
+++ b/play/src/main/groovy/com/github/goldin/plugins/gradle/play/tasks/PlayBaseTask.groovy
@@ -24,6 +24,8 @@ abstract class PlayBaseTask extends BaseTask<PlayExtension>
     @Override
     Class<PlayExtension> extensionType(){ PlayExtension }
 
+    @Requires({ c })
+    void play( Closure c ){ config(c) }
 
     @Override
     void verifyUpdateExtension ( String description )


### PR DESCRIPTION
A couple updates to the plugin after trying to use it in an plugin.
1) Put a check in place so the setup task doesn't try to install a node version that is already present in NVM. Instead just `nvm use` it.
2) When overriding the plugin configuration at the task level using the `config { ... }` method, the new extension instance is available as an argument to the closure. This change sets the `delegate` of the closure to be the extension as well, so configuration can be more concise:
Before:

```
task run(type: RunTask) {
   config { ext ->
      ext.run = ['grunt test']
   }
}

task run(type: RunTask) {
   config { it.with {
      run = ['grunt test']
   }}
}
```

After:

```
task run(type: RunTask) {
   config {
      run = ['grunt test']
   }
}
```

3) Add a wrapper method to the base tasks (except TeamCity because that didn't match the other ones) that wraps the config method with the same name as the plugin extension. This allows the above example to be rewritten as:

```
task run(type: RunTask) {
   node {
      run = ['grunt task']
   }
}
```

This makes configuration a little more explicit when combined with the changes in #2 since the configuration at the task level looks identical to the configuration of the plugin at the project level.
