### PR TITLE
Delay task evaluation so that Plugin extension is configured first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 build
 out
 download
+
+.idea

--- a/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BasePlugin.groovy
+++ b/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BasePlugin.groovy
@@ -25,16 +25,27 @@ abstract class BasePlugin implements Plugin<Project>
     @Override
     void apply ( Project project )
     {
-        final tasks = tasks( project )
+        final  extensions = extensions( project )
+        assert extensions.size() == 1
 
-        for ( String taskName in tasks.keySet())
-        {
-            addTask( project, taskName, tasks[ taskName ] )
+        final  extensionName  = extensions.keySet().toList().first()
+        final  extensionClass = extensions[ extensionName ]
+        assert extensionName && extensionClass && BaseExtension.isAssignableFrom( extensionClass )
+
+        extension(project, extensionName, extensionClass)
+
+        project.afterEvaluate {
+            final tasks = tasks( project )
+
+            for ( String taskName in tasks.keySet())
+            {
+                addTask( project, taskName, tasks[ taskName ] )
+            }
+
+            project.logger.info(
+                "Groovy [$GroovySystem.version], $project, plugin [${ this.class.name }] is applied, " +
+                "added task${ tasks.size() == 1 ? '' : 's' } '${ tasks.keySet().sort().join( '\', \'' )}'." )
         }
-
-        project.logger.info(
-            "Groovy [$GroovySystem.version], $project, plugin [${ this.class.name }] is applied, " +
-            "added task${ tasks.size() == 1 ? '' : 's' } '${ tasks.keySet().sort().join( '\', \'' )}'." )
     }
 
 

--- a/node/src/main/groovy/com/github/goldin/plugins/gradle/node/NodePlugin.groovy
+++ b/node/src/main/groovy/com/github/goldin/plugins/gradle/node/NodePlugin.groovy
@@ -67,10 +67,12 @@ class NodePlugin extends BasePlugin
     {
         super.apply( project )
 
-        final setupTask = project.tasks[ SETUP_TASK ]
+        project.afterEvaluate {
+            final setupTask = project.tasks[ SETUP_TASK ]
 
-        [ RUN_TASK, TEST_TASK, START_TASK, LIST_TASK, RESTART_ALL_TASK, STOP_TASK, STOP_ALL_TASK ].each {
-            String taskName -> project.tasks[ taskName ].dependsOn( setupTask )
+            [ RUN_TASK, TEST_TASK, START_TASK, LIST_TASK, RESTART_ALL_TASK, STOP_TASK, STOP_ALL_TASK ].each {
+                String taskName -> project.tasks.findByName(taskName)?.dependsOn( setupTask )
+            }
         }
     }
 }

--- a/node/src/main/groovy/com/github/goldin/plugins/gradle/node/tasks/NodeBaseTask.groovy
+++ b/node/src/main/groovy/com/github/goldin/plugins/gradle/node/tasks/NodeBaseTask.groovy
@@ -16,6 +16,8 @@ import org.gcontracts.annotations.Requires
  */
 abstract class NodeBaseTask extends BaseTask<NodeExtension>
 {
+    String group = 'Node'
+
     @Override
     Class<NodeExtension> extensionType(){ NodeExtension }
 

--- a/teamcity/src/main/groovy/com/github/goldin/plugins/gradle/teamcity/TeamCityPlugin.groovy
+++ b/teamcity/src/main/groovy/com/github/goldin/plugins/gradle/teamcity/TeamCityPlugin.groovy
@@ -23,13 +23,15 @@ class TeamCityPlugin extends BasePlugin
     {
         super.apply( project )
 
-        final assemblePluginTask = project.tasks[ tasks().keySet().toList().first() ]
-        final jarTask            = project.tasks.findByName( 'jar' )
-        final testTask           = project.tasks.findByName( 'test' )
-        final buildTask          = project.tasks.findByName( 'build' )
+        project.afterEvaluate {
+            final assemblePluginTask = project.tasks[ tasks().keySet().toList().first() ]
+            final jarTask            = project.tasks.findByName( 'jar' )
+            final testTask           = project.tasks.findByName( 'test' )
+            final buildTask          = project.tasks.findByName( 'build' )
 
-        if ( jarTask   ) { assemblePluginTask.dependsOn( jarTask.name   )}
-        if ( testTask  ) { assemblePluginTask.dependsOn( testTask.name  )}
-        if ( buildTask ) { buildTask.dependsOn( assemblePluginTask.name )}
+            if ( jarTask   ) { assemblePluginTask.dependsOn( jarTask.name   )}
+            if ( testTask  ) { assemblePluginTask.dependsOn( testTask.name  )}
+            if ( buildTask ) { buildTask.dependsOn( assemblePluginTask.name )}
+        }
     }
 }


### PR DESCRIPTION
The node plugin allows for configuring the tasks that are added to the project through the `node.runTasks` property but the extension is not evaluated before the plugin processes this setting during the `apply(Project)` method. This uses `project.afterEvaluate` to delay the tasks creation until the build script is fully evaluated.
