### PR TITLE
Set the config closure resolveStrategy on tasks to be DELEGATE_FIRST.

### DIFF
--- a/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BaseTask.groovy
+++ b/common/src/main/groovy/com/github/goldin/plugins/gradle/common/BaseTask.groovy
@@ -73,9 +73,10 @@ abstract class BaseTask<T extends BaseExtension> extends DefaultTask
 
         if ( this.config )
         {
-            this.extensionName   = this.name
-            this.ext             = project.extensions.create( this.extensionName, extensionType())
-            this.config.delegate = this.ext
+            this.extensionName          = this.name
+            this.ext                    = project.extensions.create( this.extensionName, extensionType())
+            this.config.delegate        = this.ext
+            this.config.resolveStrategy = Closure.DELEGATE_FIRST
             this.config( this.ext )
         }
 


### PR DESCRIPTION
This allows the call to dispatch to the extension configured as the
delegate first. By default, this is OWNER_FIRST, so the call is being
dipatched to the Gradle project instead of the extension.
